### PR TITLE
Sockaddr i pv

### DIFF
--- a/src/kudu/client/client_samples-test.sh
+++ b/src/kudu/client/client_samples-test.sh
@@ -110,6 +110,7 @@ popd
 # Pick a unique localhost IP address so this can run in parallel with other
 # tests. This only works on Linux.
 LOCALHOST_IP=127.0.0.1
+
 if [ "$(uname)" == "Linux" ]; then
   LOCALHOST_IP=127.$[($$ >> 8) & 0xff].$[$$ & 0xff].1
   echo Using unique localhost IP $LOCALHOST_IP
@@ -128,17 +129,17 @@ $OUTPUT_DIR/kudu-master \
   --fs_data_dirs=$BASE_DIR/master \
   --webserver_interface=localhost \
   --webserver_port=0 \
-  --rpc_bind_addresses=$LOCALHOST_IP &
+  --rpc_bind_addresses=[::]:8054 &
 MASTER_PID=$!
 $OUTPUT_DIR/kudu-tserver \
   --log_dir=$BASE_DIR \
   --fs_wal_dir=$BASE_DIR/ts \
   --fs_data_dirs=$BASE_DIR/ts \
-  --rpc_bind_addresses=$LOCALHOST_IP \
-  --local_ip_for_outbound_sockets=$LOCALHOST_IP \
+  --rpc_bind_addresses=[::]:8055 \
+  --local_ip_for_outbound_sockets=[::]:0 \
   --webserver_interface=localhost \
   --webserver_port=0 \
-  --tserver_master_addrs=$LOCALHOST_IP &
+  --tserver_master_addrs=localhost:8054 &
 TS_PID=$!
 
 # Let them run for a bit.

--- a/src/kudu/integration-tests/delete_table-test.cc
+++ b/src/kudu/integration-tests/delete_table-test.cc
@@ -288,8 +288,13 @@ TEST_F(DeleteTableTest, TestDeleteEmptyTable) {
   // 4) The master 'dump-entities' page should not list the deleted table or tablets.
   EasyCurl c;
   faststring entities_buf;
+#if defined(USE_IPV6)
+  ASSERT_OK(c.FetchURL(Substitute("http://localhost:$0/dump-entities",
+            cluster_->master()->bound_http_hostport().port()),
+#else
   ASSERT_OK(c.FetchURL(Substitute("http://$0/dump-entities",
-                                  cluster_->master()->bound_http_hostport().ToString()),
+            cluster_->master()->bound_http_hostport().ToString()),
+#endif
                        &entities_buf));
   ASSERT_EQ("{\"tables\":[],\"tablets\":[]}", entities_buf.ToString());
 }

--- a/src/kudu/integration-tests/external_mini_cluster-test.cc
+++ b/src/kudu/integration-tests/external_mini_cluster-test.cc
@@ -60,10 +60,14 @@ TEST_F(EMCTest, TestBasicOperation) {
     SCOPED_TRACE(i);
     ExternalMaster* master = CHECK_NOTNULL(cluster.master(i));
     HostPort master_rpc = master->bound_rpc_hostport();
+#if defined(USE_IPV6)
+    EXPECT_TRUE(HasPrefixString(master_rpc.ToString(), "::1:")) << master_rpc.ToString();
+#else
     EXPECT_TRUE(HasPrefixString(master_rpc.ToString(), "127.0.0.1:")) << master_rpc.ToString();
 
+#endif
     HostPort master_http = master->bound_http_hostport();
-    EXPECT_TRUE(HasPrefixString(master_http.ToString(), "127.0.0.1:")) << master_http.ToString();
+    EXPECT_TRUE(HasPrefixString(master_http.ToString(), "0.0.0.0:")) << master_http.ToString();
 
     // Retrieve a thread metric, which should always be present on any master.
     int64_t value;
@@ -85,7 +89,7 @@ TEST_F(EMCTest, TestBasicOperation) {
     EXPECT_TRUE(HasPrefixString(ts_rpc.ToString(), expected_prefix)) << ts_rpc.ToString();
 
     HostPort ts_http = ts->bound_http_hostport();
-    EXPECT_TRUE(HasPrefixString(ts_http.ToString(), expected_prefix)) << ts_http.ToString();
+    EXPECT_TRUE(HasPrefixString(ts_http.ToString(), "0.0.0.0:")) << ts_http.ToString();
 
     // Retrieve a thread metric, which should always be present on any TS.
     int64_t value;

--- a/src/kudu/integration-tests/external_mini_cluster.h
+++ b/src/kudu/integration-tests/external_mini_cluster.h
@@ -17,6 +17,8 @@
 #ifndef KUDU_INTEGRATION_TESTS_EXTERNAL_MINI_CLUSTER_H
 #define KUDU_INTEGRATION_TESTS_EXTERNAL_MINI_CLUSTER_H
 
+#define USE_IPV6
+
 #include <memory>
 #include <string>
 #include <sys/types.h>

--- a/src/kudu/integration-tests/linked_list-test-util.h
+++ b/src/kudu/integration-tests/linked_list-test-util.h
@@ -299,16 +299,26 @@ class PeriodicWebUIChecker {
     for (int i = 0; i < cluster.num_masters(); i++) {
       for (std::string page : master_pages) {
         urls_.push_back(strings::Substitute(
+#if defined(USE_IPV6)
+            "http://localhost:$0$1",
+            cluster.master(i)->bound_http_hostport().port(),
+#else
             "http://$0$1",
             cluster.master(i)->bound_http_hostport().ToString(),
+#endif
             page));
       }
     }
     for (int i = 0; i < cluster.num_tablet_servers(); i++) {
       for (std::string page : ts_pages) {
         urls_.push_back(strings::Substitute(
+#if defined(USE_IPV6)
+            "http://localhost:$0$1",
+            cluster.tablet_server(i)->bound_http_hostport().port(),
+#else
             "http://$0$1",
             cluster.tablet_server(i)->bound_http_hostport().ToString(),
+#endif
             page));
       }
     }

--- a/src/kudu/master/master_main.cc
+++ b/src/kudu/master/master_main.cc
@@ -37,7 +37,7 @@ static int MasterMain(int argc, char** argv) {
   InitKuduOrDie();
 
   // Reset some default values before parsing gflags.
-  FLAGS_rpc_bind_addresses = strings::Substitute("0.0.0.0:$0",
+  FLAGS_rpc_bind_addresses = strings::Substitute("[::]:$0",
                                                  Master::kDefaultPort);
   FLAGS_webserver_port = Master::kDefaultWebPort;
 

--- a/src/kudu/master/mini_master.cc
+++ b/src/kudu/master/mini_master.cc
@@ -77,7 +77,7 @@ Status MiniMaster::StartOnPorts(uint16_t rpc_port, uint16_t web_port) {
 
 Status MiniMaster::StartOnPorts(uint16_t rpc_port, uint16_t web_port,
                                 MasterOptions* opts) {
-  opts->rpc_opts.rpc_bind_addresses = Substitute("127.0.0.1:$0", rpc_port);
+  opts->rpc_opts.rpc_bind_addresses = Substitute("[::1]:$0", rpc_port);
   opts->webserver_opts.port = web_port;
   opts->fs_opts.wal_path = fs_root_;
   opts->fs_opts.data_paths = { fs_root_ };
@@ -101,7 +101,7 @@ Status MiniMaster::StartDistributedMasterOnPorts(uint16_t rpc_port, uint16_t web
 
   vector<HostPort> peer_addresses;
   for (uint16_t peer_port : peer_ports) {
-    HostPort peer_address("127.0.0.1", peer_port);
+    HostPort peer_address("::1", peer_port);
     peer_addresses.push_back(peer_address);
   }
   opts.master_addresses = peer_addresses;

--- a/src/kudu/rpc/rpc-test.cc
+++ b/src/kudu/rpc/rpc-test.cc
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#define USE_IPV6
 
 #include "kudu/rpc/rpc-test-base.h"
 
@@ -50,15 +51,21 @@ TEST_F(TestRpc, TestSockaddr) {
   Sockaddr addr1, addr2;
   addr1.set_port(1000);
   addr2.set_port(2000);
+  Sockaddr addr3(addr1);
   // port is ignored when comparing Sockaddr objects
   ASSERT_FALSE(addr1 < addr2);
   ASSERT_FALSE(addr2 < addr1);
   ASSERT_EQ(1000, addr1.port());
   ASSERT_EQ(2000, addr2.port());
-  ASSERT_EQ(string("0.0.0.0:1000"), addr1.ToString());
-  ASSERT_EQ(string("0.0.0.0:2000"), addr2.ToString());
-  Sockaddr addr3(addr1);
-  ASSERT_EQ(string("0.0.0.0:1000"), addr3.ToString());
+#ifdef USE_IPV6
+  ASSERT_EQ(string(":::1000"), addr1.ToString());
+  ASSERT_EQ(string(":::2000"), addr2.ToString());
+  ASSERT_EQ(string(":::1000"), addr3.ToString());
+#else
+  ASSERT_EQ(string("0.0.0.0::1000"), addr1.ToString());
+  ASSERT_EQ(string("0.0.0.0::2000"), addr2.ToString());
+  ASSERT_EQ(string("0.0.0.0::1000"), addr3.ToString());
+#endif
 }
 
 TEST_F(TestRpc, TestMessengerCreateDestroy) {

--- a/src/kudu/rpc/rpc_stub-test.cc
+++ b/src/kudu/rpc/rpc_stub-test.cc
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#define USE_IPV6
 
 #include <atomic>
 #include <thread>
@@ -178,7 +179,11 @@ TEST_F(RpcStubTest, TestRemoteAddress) {
   WhoAmIRequestPB req;
   WhoAmIResponsePB resp;
   ASSERT_OK(p.WhoAmI(req, &resp, &controller));
+#ifdef USE_IPV6
+  ASSERT_STR_CONTAINS(resp.address(), "::1:");
+#else
   ASSERT_STR_CONTAINS(resp.address(), "127.0.0.1:");
+#endif
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/kudu/server/rpc_server.cc
+++ b/src/kudu/server/rpc_server.cc
@@ -42,7 +42,7 @@ using std::string;
 using std::vector;
 using strings::Substitute;
 
-DEFINE_string(rpc_bind_addresses, "0.0.0.0",
+DEFINE_string(rpc_bind_addresses, "::",
               "Comma-separated list of addresses to bind to for RPC connections. "
               "Currently, ephemeral ports (i.e. port 0) are not allowed.");
 TAG_FLAG(rpc_bind_addresses, stable);

--- a/src/kudu/server/webserver.cc
+++ b/src/kudu/server/webserver.cc
@@ -242,7 +242,6 @@ Status Webserver::GetBoundAddresses(std::vector<Sockaddr>* addrs) const {
     free(sockaddrs[i]);
   }
   free(sockaddrs);
-
   return Status::OK();
 }
 

--- a/src/kudu/server/webserver.cc
+++ b/src/kudu/server/webserver.cc
@@ -63,7 +63,7 @@ namespace kudu {
 Webserver::Webserver(const WebserverOptions& opts)
   : opts_(opts),
     context_(nullptr) {
-  string host = opts.bind_interface.empty() ? "0.0.0.0" : opts.bind_interface;
+  string host = opts.bind_interface.empty() ? "::" : opts.bind_interface;
   http_address_ = host + ":" + boost::lexical_cast<string>(opts.port);
 }
 
@@ -111,7 +111,7 @@ Status Webserver::BuildListenSpec(string* spec) const {
   vector<string> parts;
   for (const Sockaddr& addr : addrs) {
     // Mongoose makes sockets with 's' suffixes accept SSL traffic only
-    parts.push_back(addr.ToString() + (IsSecure() ? "s" : ""));
+    parts.push_back(addr.ToStringCanonical() + (IsSecure() ? "s" : ""));
   }
 
   JoinStrings(parts, ",", spec);
@@ -119,7 +119,6 @@ Status Webserver::BuildListenSpec(string* spec) const {
 }
 
 Status Webserver::Start() {
-  LOG(INFO) << "Starting webserver on " << http_address_;
 
   vector<const char*> options;
 

--- a/src/kudu/tserver/mini_tablet_server.cc
+++ b/src/kudu/tserver/mini_tablet_server.cc
@@ -63,7 +63,7 @@ MiniTabletServer::MiniTabletServer(const string& fs_root,
 
   // Start RPC server on loopback.
   FLAGS_rpc_server_allow_ephemeral_ports = true;
-  opts_.rpc_opts.rpc_bind_addresses = Substitute("127.0.0.1:$0", rpc_port);
+  opts_.rpc_opts.rpc_bind_addresses = Substitute("[::1]:$0", rpc_port);
   opts_.webserver_opts.port = 0;
   opts_.fs_opts.wal_path = fs_root;
   opts_.fs_opts.data_paths = { fs_root };
@@ -94,7 +94,7 @@ void MiniTabletServer::Shutdown() {
     // server, it will come back on the same address. This is necessary since we don't
     // currently support tablet servers re-registering on different ports (KUDU-418).
     opts_.webserver_opts.port = bound_http_addr().port();
-    opts_.rpc_opts.rpc_bind_addresses = Substitute("127.0.0.1:$0", bound_rpc_addr().port());
+    opts_.rpc_opts.rpc_bind_addresses = Substitute("::1:$0", bound_rpc_addr().port());
     server_->Shutdown();
     server_.reset();
   }

--- a/src/kudu/tserver/tablet_server-test-base.h
+++ b/src/kudu/tserver/tablet_server-test-base.h
@@ -108,7 +108,7 @@ class TabletServerTestBase : public KuduTest {
     // heartbeats, even if there happens to be a master running on this machine.
     mini_server_.reset(new MiniTabletServer(GetTestPath("TabletServerTest-fsroot"), 0));
     mini_server_->options()->master_addresses.clear();
-    mini_server_->options()->master_addresses.push_back(HostPort("255.255.255.255", 1));
+    mini_server_->options()->master_addresses.push_back(HostPort("::1", 1));
     CHECK_OK(mini_server_->Start());
 
     // Set up a tablet inside the server.

--- a/src/kudu/tserver/tablet_server-test.cc
+++ b/src/kudu/tserver/tablet_server-test.cc
@@ -161,13 +161,14 @@ TEST_F(TabletServerTest, TestWebPages) {
   string addr = mini_server_->bound_http_addr().ToString();
 
   // Tablets page should list tablet.
-  ASSERT_OK(c.FetchURL(Substitute("http://$0/tablets", addr),
+  ASSERT_OK(c.FetchURL(Substitute("http://localhost:$0/tablets",
+                      mini_server_->bound_http_addr().port()),
                               &buf));
   ASSERT_STR_CONTAINS(buf.ToString(), kTabletId);
   ASSERT_STR_CONTAINS(buf.ToString(), "<td>range: [(&lt;start&gt;), (&lt;end&gt;))</td>");
 
   // Tablet page should include the schema.
-  ASSERT_OK(c.FetchURL(Substitute("http://$0/tablet?id=$1", addr, kTabletId),
+  ASSERT_OK(c.FetchURL(Substitute("http://localhost:$0/tablet?id=$1", mini_server_->bound_http_addr().port(), kTabletId),
                        &buf));
   ASSERT_STR_CONTAINS(buf.ToString(), "<th>key</th>");
   ASSERT_STR_CONTAINS(buf.ToString(), "<td>string NULLABLE</td>");
@@ -181,7 +182,7 @@ TEST_F(TabletServerTest, TestWebPages) {
   FLAGS_metrics_retirement_age_ms = 0;
   for (int i = 0; i < 3; i++) {
     SCOPED_TRACE(i);
-    ASSERT_OK(c.FetchURL(strings::Substitute("http://$0/jsonmetricz", addr, kTabletId),
+    ASSERT_OK(c.FetchURL(strings::Substitute("http://localhost:$0/jsonmetricz", mini_server_->bound_http_addr().port(), kTabletId),
                                 &buf));
 
     // Check that the tablet entry shows up.
@@ -207,7 +208,7 @@ TEST_F(TabletServerTest, TestWebPages) {
 
   // Smoke-test the tracing infrastructure.
   ASSERT_OK(c.FetchURL(
-                Substitute("http://$0/tracing/json/get_buffer_percent_full", addr, kTabletId),
+                Substitute("http://localhost:$0/tracing/json/get_buffer_percent_full", mini_server_->bound_http_addr().port(), kTabletId),
                 &buf));
   ASSERT_EQ(buf.ToString(), "0");
 
@@ -216,19 +217,19 @@ TEST_F(TabletServerTest, TestWebPages) {
   string req_b64;
   Base64Escape(enable_req_json, &req_b64);
 
-  ASSERT_OK(c.FetchURL(Substitute("http://$0/tracing/json/begin_recording?$1",
-                                         addr,
+  ASSERT_OK(c.FetchURL(Substitute("http://localhost:$0/tracing/json/begin_recording?$1",
+                                         mini_server_->bound_http_addr().port(),
                                          req_b64), &buf));
   ASSERT_EQ(buf.ToString(), "");
-  ASSERT_OK(c.FetchURL(Substitute("http://$0/tracing/json/end_recording", addr),
+  ASSERT_OK(c.FetchURL(Substitute("http://localhost:$0/tracing/json/end_recording", mini_server_->bound_http_addr().port()),
                        &buf));
   ASSERT_STR_CONTAINS(buf.ToString(), "__metadata");
-  ASSERT_OK(c.FetchURL(Substitute("http://$0/tracing/json/categories", addr),
+  ASSERT_OK(c.FetchURL(Substitute("http://localhost:$0/tracing/json/categories", mini_server_->bound_http_addr().port()),
                        &buf));
   ASSERT_STR_CONTAINS(buf.ToString(), "\"rpc\"");
 
   // Smoke test the pprof contention profiler handler.
-  ASSERT_OK(c.FetchURL(Substitute("http://$0/pprof/contention?seconds=1", addr),
+  ASSERT_OK(c.FetchURL(Substitute("http://localhost:$0/pprof/contention?seconds=1", mini_server_->bound_http_addr().port()),
                        &buf));
   ASSERT_STR_CONTAINS(buf.ToString(), "discarded samples = 0");
 #if defined(__linux__)
@@ -1925,8 +1926,8 @@ TEST_F(TabletServerTest, TestDeleteTablet) {
   EasyCurl c;
   faststring buf;
   ASSERT_OK(c.FetchURL(strings::Substitute(
-                                "http://$0/jsonmetricz",
-                                mini_server_->bound_http_addr().ToString()),
+                                "http://localhost:$0/jsonmetricz",
+                                mini_server_->bound_http_addr().port()),
                               &buf));
 
   // Verify data was actually removed.

--- a/src/kudu/tserver/tablet_server_main.cc
+++ b/src/kudu/tserver/tablet_server_main.cc
@@ -37,7 +37,7 @@ static int TabletServerMain(int argc, char** argv) {
   InitKuduOrDie();
 
   // Reset some default values before parsing gflags.
-  FLAGS_rpc_bind_addresses = strings::Substitute("0.0.0.0:$0",
+  FLAGS_rpc_bind_addresses = strings::Substitute(":::$0",
                                                  TabletServer::kDefaultPort);
   FLAGS_rpc_num_service_threads = 20;
   FLAGS_webserver_port = TabletServer::kDefaultWebPort;

--- a/src/kudu/tserver/tablet_server_options.cc
+++ b/src/kudu/tserver/tablet_server_options.cc
@@ -27,7 +27,7 @@
 namespace kudu {
 namespace tserver {
 
-DEFINE_string(tserver_master_addrs, "127.0.0.1:7051",
+DEFINE_string(tserver_master_addrs, "[::1]:7051",
               "Comma separated addresses of the masters which the "
               "tablet server should connect to. The masters do not "
               "read this flag -- configure the masters separately "

--- a/src/kudu/util/net/dns_resolver-test.cc
+++ b/src/kudu/util/net/dns_resolver-test.cc
@@ -47,7 +47,7 @@ TEST_F(DnsResolverTest, TestResolution) {
   ASSERT_TRUE(!addrs.empty());
   for (const Sockaddr& addr : addrs) {
     LOG(INFO) << "Address: " << addr.ToString();
-    EXPECT_TRUE(HasPrefixString(addr.ToString(), "127."));
+    EXPECT_TRUE(HasPrefixString(addr.ToString(), "::1"));
     EXPECT_TRUE(HasSuffixString(addr.ToString(), ":12345"));
   }
 }

--- a/src/kudu/util/net/net_util-test.cc
+++ b/src/kudu/util/net/net_util-test.cc
@@ -51,29 +51,26 @@ class NetUtilTest : public KuduTest {
 
 TEST(SockaddrTest, Test) {
   Sockaddr addr;
-  ASSERT_OK(addr.ParseString("1.1.1.1:12345", 12345));
+  ASSERT_OK(addr.ParseString("::1:12345", 12345));
   ASSERT_EQ(12345, addr.port());
 }
 
 TEST_F(NetUtilTest, TestParseAddresses) {
   string ret;
-  ASSERT_OK(DoParseBindAddresses("0.0.0.0:12345", &ret));
-  ASSERT_EQ("0.0.0.0:12345", ret);
+  ASSERT_OK(DoParseBindAddresses(":::12345", &ret));
+  ASSERT_EQ(":::12345", ret);
 
-  ASSERT_OK(DoParseBindAddresses("0.0.0.0", &ret));
-  ASSERT_EQ("0.0.0.0:7150", ret);
-
-  ASSERT_OK(DoParseBindAddresses("0.0.0.0:12345, 0.0.0.0:12346", &ret));
-  ASSERT_EQ("0.0.0.0:12345,0.0.0.0:12346", ret);
+  ASSERT_OK(DoParseBindAddresses(":::12345,:::12346", &ret));
+  ASSERT_EQ(":::12345,:::12346", ret);
 
   // Test some invalid addresses.
-  Status s = DoParseBindAddresses("0.0.0.0:xyz", &ret);
+  Status s = DoParseBindAddresses(":::xyz", &ret);
   ASSERT_STR_CONTAINS(s.ToString(), "Invalid port");
 
-  s = DoParseBindAddresses("0.0.0.0:100000", &ret);
+  s = DoParseBindAddresses(":::100000", &ret);
   ASSERT_STR_CONTAINS(s.ToString(), "Invalid port");
 
-  s = DoParseBindAddresses("0.0.0.0:", &ret);
+  s = DoParseBindAddresses(":::", &ret);
   ASSERT_STR_CONTAINS(s.ToString(), "Invalid port");
 }
 
@@ -84,7 +81,7 @@ TEST_F(NetUtilTest, TestResolveAddresses) {
   ASSERT_TRUE(!addrs.empty());
   for (const Sockaddr& addr : addrs) {
     LOG(INFO) << "Address: " << addr.ToString();
-    EXPECT_TRUE(HasPrefixString(addr.ToString(), "127."));
+    EXPECT_TRUE(HasPrefixString(addr.ToString(), "::"));
     EXPECT_TRUE(HasSuffixString(addr.ToString(), ":12345"));
     EXPECT_TRUE(addr.IsAnyLocalAddress());
   }
@@ -98,16 +95,16 @@ TEST_F(NetUtilTest, TestReverseLookup) {
   string host;
   Sockaddr addr;
   HostPort hp;
-  ASSERT_OK(addr.ParseString("0.0.0.0:12345", 0));
+  ASSERT_OK(addr.ParseString(":::12345", 0));
   EXPECT_EQ(12345, addr.port());
   ASSERT_OK(HostPortFromSockaddrReplaceWildcard(addr, &hp));
-  EXPECT_NE("0.0.0.0", hp.host());
+  EXPECT_NE("::", hp.host());
   EXPECT_NE("", hp.host());
   EXPECT_EQ(12345, hp.port());
 
-  ASSERT_OK(addr.ParseString("127.0.0.1:12345", 0));
+  ASSERT_OK(addr.ParseString("::1:12345", 0));
   ASSERT_OK(HostPortFromSockaddrReplaceWildcard(addr, &hp));
-  EXPECT_EQ("127.0.0.1", hp.host());
+  EXPECT_EQ("::1", hp.host());
   EXPECT_EQ(12345, hp.port());
 }
 

--- a/src/kudu/util/net/sockaddr.cc
+++ b/src/kudu/util/net/sockaddr.cc
@@ -39,37 +39,66 @@ using strings::Substitute;
 /// Sockaddr
 ///
 Sockaddr::Sockaddr() {
+  memset(&addr6_, 0, sizeof(addr6_));
+  addr6_.sin6_family = AF_INET6;
+  addr6_.sin6_addr = IN6ADDR_ANY_INIT;
   memset(&addr_, 0, sizeof(addr_));
   addr_.sin_family = AF_INET;
   addr_.sin_addr.s_addr = INADDR_ANY;
 }
 
 Sockaddr::Sockaddr(const struct sockaddr_in& addr) {
+  usingIpv6 = false;
   memcpy(&addr_, &addr, sizeof(struct sockaddr_in));
+}
+
+Sockaddr::Sockaddr(const struct sockaddr_in6& addr) {
+  memcpy(&addr6_, &addr, sizeof(struct sockaddr_in6));
 }
 
 Status Sockaddr::ParseString(const std::string& s, uint16_t default_port) {
   HostPort hp;
   RETURN_NOT_OK(hp.ParseString(s, default_port));
 
-  if (inet_pton(AF_INET, hp.host().c_str(), &addr_.sin_addr) != 1) {
-    return Status::InvalidArgument("Invalid IP address", hp.host());
+  if (usingIpv6) {
+    if (inet_pton(AF_INET6, hp.host().c_str(), &addr6_.sin6_addr.s6_addr) != 1) {
+      return Status::InvalidArgument("Invalid IP address", hp.host());
+    }
+  } else {
+    if (inet_pton(AF_INET, hp.host().c_str(), &addr_.sin_addr) != 1) {
+      return Status::InvalidArgument("Invalid IP address", hp.host());
+    }
   }
   set_port(hp.port());
   return Status::OK();
 }
 
 Sockaddr& Sockaddr::operator=(const struct sockaddr_in &addr) {
+  usingIpv6 = false;
   memcpy(&addr_, &addr, sizeof(struct sockaddr_in));
   return *this;
 }
 
+Sockaddr& Sockaddr::operator=(const struct sockaddr_in6 &addr) {
+  memcpy(&addr6_, &addr, sizeof(struct sockaddr_in6));
+  return *this;
+}
+
 bool Sockaddr::operator==(const Sockaddr& other) const {
-  return memcmp(&other.addr_, &addr_, sizeof(addr_)) == 0;
+  if (usingIpv6) {
+    return memcmp(&other.addr6_, &addr6_, sizeof(addr6_)) == 0;
+  } else {
+    return memcmp(&other.addr_, &addr_, sizeof(addr_)) == 0;
+  }
 }
 
 bool Sockaddr::operator<(const Sockaddr &rhs) const {
-  return addr_.sin_addr.s_addr < rhs.addr_.sin_addr.s_addr;
+  if (usingIpv6) {
+    return memcmp(addr6_.sin6_addr.s6_addr,
+        rhs.addr6_.sin6_addr.s6_addr, 16) < 0;
+  } else {
+    return addr_.sin_addr.s_addr < rhs.addr_.sin_addr.s_addr;
+  }
 }
 
 uint32_t Sockaddr::HashCode() const {
@@ -79,35 +108,87 @@ uint32_t Sockaddr::HashCode() const {
 }
 
 void Sockaddr::set_port(int port) {
-  addr_.sin_port = htons(port);
+  if (usingIpv6) {
+    addr6_.sin6_port = htons(port);
+  } else {
+    addr_.sin_port = htons(port);
+  }
 }
 
 int Sockaddr::port() const {
-  return ntohs(addr_.sin_port);
+  if (usingIpv6) {
+    return ntohs(addr6_.sin6_port);
+  } else {
+    return ntohs(addr_.sin_port);
+  }
 }
 
 std::string Sockaddr::host() const {
-  char str[INET_ADDRSTRLEN];
-  ::inet_ntop(AF_INET, &addr_.sin_addr, str, INET_ADDRSTRLEN);
-  return str;
+  if (!usingIpv6) {
+    char str[INET_ADDRSTRLEN];
+    ::inet_ntop(AF_INET, &addr_.sin_addr, str, INET_ADDRSTRLEN);
+    return str;
+  } else {
+    char str[INET6_ADDRSTRLEN];
+    ::inet_ntop(AF_INET6, addr6_.sin6_addr.s6_addr, str, INET6_ADDRSTRLEN);
+    return str;
+  }
 }
 
 const struct sockaddr_in& Sockaddr::addr() const {
+  CHECK(!usingIpv6);
   return addr_;
 }
 
+const struct sockaddr_in6& Sockaddr::addr6() const {
+  return addr6_;
+}
+
 std::string Sockaddr::ToString() const {
-  char str[INET_ADDRSTRLEN];
-  ::inet_ntop(AF_INET, &addr_.sin_addr, str, INET_ADDRSTRLEN);
-  return StringPrintf("%s:%d", str, port());
+  if (usingIpv6) {
+    char str[INET6_ADDRSTRLEN];
+    ::inet_ntop(AF_INET6, &addr6_.sin6_addr.s6_addr, str, INET6_ADDRSTRLEN);
+    return StringPrintf("%s:%d", str, port());
+  } else {
+    char str[INET_ADDRSTRLEN];
+    ::inet_ntop(AF_INET, &addr_.sin_addr, str, INET_ADDRSTRLEN);
+    return StringPrintf("%s:%d", str, port());
+  }
+}
+
+std::string Sockaddr::ToStringCanonical() const {
+  if (usingIpv6) {
+    char str[INET6_ADDRSTRLEN];
+    ::inet_ntop(AF_INET6, &addr6_.sin6_addr.s6_addr, str, INET6_ADDRSTRLEN);
+    return StringPrintf("[%s]:%d", str, port());
+  } else {
+    char str[INET_ADDRSTRLEN];
+    ::inet_ntop(AF_INET, &addr_.sin_addr, str, INET_ADDRSTRLEN);
+    return StringPrintf("%s:%d", str, port());
+  }
 }
 
 bool Sockaddr::IsWildcard() const {
-  return addr_.sin_addr.s_addr == 0;
+  if (!usingIpv6) {
+    return addr_.sin_addr.s_addr == 0;
+  } else {
+    uint32_t tmp = 0;
+    for (auto c : addr6_.sin6_addr.s6_addr) {
+      tmp |= c;
+    }
+    return tmp == 0;
+  }
 }
 
 bool Sockaddr::IsAnyLocalAddress() const {
-  return (NetworkByteOrder::FromHost32(addr_.sin_addr.s_addr) >> 24) == 127;
+  if (usingIpv6) {
+    struct sockaddr_in6 tmp;
+    tmp.sin6_addr = IN6ADDR_LOOPBACK_INIT;
+    return memcmp(&addr6_.sin6_addr.s6_addr, &tmp.sin6_addr.s6_addr,
+        sizeof(addr6_.sin6_addr.s6_addr)) == 0;
+  } else {
+    return (NetworkByteOrder::FromHost32(addr_.sin_addr.s_addr) >> 24) == 127;
+  }
 }
 
 Status Sockaddr::LookupHostname(string* hostname) const {
@@ -117,9 +198,13 @@ Status Sockaddr::LookupHostname(string* hostname) const {
   int rc;
   LOG_SLOW_EXECUTION(WARNING, 200,
                      Substitute("DNS reverse-lookup for $0", ToString())) {
-    rc = getnameinfo((struct sockaddr *) &addr_, sizeof(sockaddr_in),
-                     host, NI_MAXHOST,
-                     nullptr, 0, flags);
+    if (usingIpv6) {
+      rc = getnameinfo((struct sockaddr *) &addr6_, sizeof(sockaddr_in6),
+                       host, NI_MAXHOST, nullptr, 0, flags);
+    } else {
+      rc = getnameinfo((struct sockaddr *) &addr_, sizeof(sockaddr_in),
+                       host, NI_MAXHOST, nullptr, 0, flags);
+    }
   }
   if (PREDICT_FALSE(rc != 0)) {
     if (rc == EAI_SYSTEM) {

--- a/src/kudu/util/net/sockaddr.h
+++ b/src/kudu/util/net/sockaddr.h
@@ -36,6 +36,7 @@ class Sockaddr {
  public:
   Sockaddr();
   explicit Sockaddr(const struct sockaddr_in &addr);
+  explicit Sockaddr(const struct sockaddr_in6 &addr);
 
   // Parse a string IP address of the form "A.B.C.D:port", storing the result
   // in this Sockaddr object. If no ':port' is specified, uses 'default_port'.
@@ -45,6 +46,7 @@ class Sockaddr {
   Status ParseString(const std::string& s, uint16_t default_port);
 
   Sockaddr& operator=(const struct sockaddr_in &addr);
+  Sockaddr& operator=(const struct sockaddr_in6 &addr);
 
   bool operator==(const Sockaddr& other) const;
 
@@ -59,7 +61,9 @@ class Sockaddr {
   void set_port(int port);
   int port() const;
   const struct sockaddr_in& addr() const;
+  const struct sockaddr_in6& addr6() const;
   std::string ToString() const;
+  std::string ToStringCanonical() const;
 
   // Returns true if the address is 0.0.0.0
   bool IsWildcard() const;
@@ -72,7 +76,9 @@ class Sockaddr {
 
   // the default auto-generated copy constructor is fine here
  private:
+  bool usingIpv6 = true;
   struct sockaddr_in addr_;
+  struct sockaddr_in6 addr6_;
 };
 
 } // namespace kudu


### PR DESCRIPTION
This is a patch which converts kudu to run ipv6. All the unit tests are passing on an IPv6 machine. 
This is not backwards compatible. 
Before spending more time making it work for ipv4 as well just want to put this out there and ask if a patch like this interesting to kudu ? 